### PR TITLE
Feat/베스트셀러및 베스트리뷰 개발

### DIFF
--- a/src/main/java/com/book/heejinbook/controller/BookController.java
+++ b/src/main/java/com/book/heejinbook/controller/BookController.java
@@ -2,6 +2,7 @@ package com.book.heejinbook.controller;
 
 import com.book.heejinbook.dto.book.request.BookListRequest;
 import com.book.heejinbook.dto.book.request.KakaoBookDataRequest;
+import com.book.heejinbook.dto.book.response.BestBooksResponse;
 import com.book.heejinbook.dto.book.response.BookListResponse;
 import com.book.heejinbook.dto.book.response.DetailBookResponse;
 import com.book.heejinbook.dto.book.response.KakaoBookResponse;
@@ -18,6 +19,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -47,6 +50,13 @@ public class BookController {
 
         return ApiUtils.success(HttpStatus.OK, "북 디테일 조회 성공", bookService.getDetail(bookId));
     }
+
+    @Operation(summary = "평균 별점 순 베스트셀러")
+    @GetMapping("/best-books")
+    public Response<List<BestBooksResponse>> getBestBooks() {
+        return ApiUtils.success(HttpStatus.OK, "베스트셀러 조회 성공", bookService.getBestBooks());
+    }
+
 
 
 }

--- a/src/main/java/com/book/heejinbook/controller/ReviewController.java
+++ b/src/main/java/com/book/heejinbook/controller/ReviewController.java
@@ -38,7 +38,7 @@ public class ReviewController {
 
     @Auth
     @GetMapping("/swiper/{book_id}")
-    @Operation(summary = "swiper 리뷰 리스트 조회 (랜덤으로 내려감)")
+    @Operation(summary = "swiper 리뷰 리스트 조회 (좋아요 개수 순)")
     public Response<List<ReviewSwiperResponse>> getSwiperList(@PathVariable("book_id") Long bookId, @RequestParam Integer size) {
         return ApiUtils.success(HttpStatus.OK, "리뷰 조회 완료", reviewService.getSwiperList(bookId, size));
     }

--- a/src/main/java/com/book/heejinbook/dto/book/response/BestBooksResponse.java
+++ b/src/main/java/com/book/heejinbook/dto/book/response/BestBooksResponse.java
@@ -1,0 +1,20 @@
+package com.book.heejinbook.dto.book.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BestBooksResponse {
+
+    private Long bookId;
+    private String title;
+    private String author;
+    private String thumbnail;
+    private Long reviewCount;
+    private Double avgRating;
+    private String description;
+
+}

--- a/src/main/java/com/book/heejinbook/dto/book/response/DetailBookResponse.java
+++ b/src/main/java/com/book/heejinbook/dto/book/response/DetailBookResponse.java
@@ -25,8 +25,9 @@ public class DetailBookResponse {
     private Boolean isLibrary;
     private Boolean isWriteReview;
     private Double avgRating;
+    private Boolean isBest;
 
-    public static DetailBookResponse from(Book book, Long reviewCount, Boolean isLibrary, Boolean isWriteReview, Double avgRating) {
+    public static DetailBookResponse of(Book book, Long reviewCount, Boolean isLibrary, Boolean isWriteReview, Double avgRating, Boolean isBest) {
         return DetailBookResponse.builder()
                 .bookId(book.getId())
                 .title(book.getTitle())
@@ -41,6 +42,7 @@ public class DetailBookResponse {
                 .isLibrary(isLibrary)
                 .isWriteReview(isWriteReview)
                 .avgRating(Math.round(avgRating*10)/10.0)
+                .isBest(isBest)
                 .build();
     }
 

--- a/src/main/java/com/book/heejinbook/dto/review/response/ReviewSwiperResponse.java
+++ b/src/main/java/com/book/heejinbook/dto/review/response/ReviewSwiperResponse.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -21,8 +23,21 @@ public class ReviewSwiperResponse {
     private String reviewAuthorProfileUrl;
     private String reviewContents;
     private String reviewCreatedAt;
-    private Integer likeCount;
+    private Long likeCount;
     private Boolean isLike;
+
+    public ReviewSwiperResponse(Long reviewId, Long bookId, String reviewAuthor, String reviewTitle, String reviewPhrase, String reviewAuthorProfileUrl, String reviewContents, Instant reviewCreatedAt, Long likeCount, Boolean isLike) {
+        this.reviewId = reviewId;
+        this.bookId = bookId;
+        this.reviewAuthor = reviewAuthor;
+        this.reviewTitle = reviewTitle;
+        this.reviewPhrase = reviewPhrase;
+        this.reviewAuthorProfileUrl = reviewAuthorProfileUrl;
+        this.reviewContents = reviewContents;
+        this.reviewCreatedAt = DateUtils.convertToString(reviewCreatedAt);
+        this.likeCount = likeCount;
+        this.isLike = isLike;
+    }
 
     public static ReviewSwiperResponse from(Review review, Boolean isLike) {
         return ReviewSwiperResponse.builder()
@@ -34,7 +49,7 @@ public class ReviewSwiperResponse {
                 .reviewPhrase(review.getPhrase())
                 .reviewCreatedAt(DateUtils.convertToString(review.getCreatedAt()))
                 .bookId(review.getBook().getId())
-                .likeCount(review.getLikeCount())
+                .likeCount((long)review.getLikeCount())
                 .isLike(isLike)
                 .build();
     }

--- a/src/main/java/com/book/heejinbook/repository/book/BookCustomRepository.java
+++ b/src/main/java/com/book/heejinbook/repository/book/BookCustomRepository.java
@@ -1,8 +1,10 @@
 package com.book.heejinbook.repository.book;
 
 import com.book.heejinbook.dto.book.request.BookListRequest;
+import com.book.heejinbook.dto.book.response.BestBooksResponse;
 import com.book.heejinbook.dto.book.response.BookListResponse;
 import com.book.heejinbook.dto.vo.CustomPageableRequest;
+import com.book.heejinbook.entity.Book;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -12,4 +14,7 @@ public interface BookCustomRepository {
 
     Page<BookListResponse> findBookList(BookListRequest bookListRequest, Pageable pageable);
 
+    List<BestBooksResponse> findBestBookList();
+
+    Boolean existBestBooks(Book book);
 }

--- a/src/main/java/com/book/heejinbook/repository/review/ReviewCustomRepository.java
+++ b/src/main/java/com/book/heejinbook/repository/review/ReviewCustomRepository.java
@@ -1,12 +1,17 @@
 package com.book.heejinbook.repository.review;
 
 import com.book.heejinbook.dto.review.response.ReviewListResponse;
+import com.book.heejinbook.dto.review.response.ReviewSwiperResponse;
 import com.book.heejinbook.entity.Book;
+import com.book.heejinbook.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface ReviewCustomRepository {
 
     Page<ReviewListResponse> findReviewList(Book book, Pageable pageable, String sort);
+    List<ReviewSwiperResponse> findBestReviewList(Book book, User user, Integer size);
 
 }

--- a/src/main/java/com/book/heejinbook/service/BookService.java
+++ b/src/main/java/com/book/heejinbook/service/BookService.java
@@ -2,6 +2,7 @@ package com.book.heejinbook.service;
 
 import com.book.heejinbook.dto.book.request.BookListRequest;
 import com.book.heejinbook.dto.book.request.KakaoBookDataRequest;
+import com.book.heejinbook.dto.book.response.BestBooksResponse;
 import com.book.heejinbook.dto.book.response.BookListResponse;
 import com.book.heejinbook.dto.book.response.DetailBookResponse;
 import com.book.heejinbook.dto.book.response.KakaoBookResponse;
@@ -23,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -82,7 +84,12 @@ public class BookService {
         Double avgRating = reviewRepository.avgRatingByBook(book);
         Boolean isLibrary = libraryRepository.existsByBookAndUser(book, user);
         Boolean isWriteReview = reviewRepository.existsByBookAndUserAndIsDeletedFalse(book, user);
-        return DetailBookResponse.from(book, reviewCount, isLibrary, isWriteReview, avgRating);
+        Boolean isBest = bookCustomRepository.existBestBooks(book);
+        return DetailBookResponse.of(book, reviewCount, isLibrary, isWriteReview, avgRating, isBest);
+    }
+
+    public List<BestBooksResponse> getBestBooks() {
+        return bookCustomRepository.findBestBookList();
     }
 
     private Book validBook(Long bookId) {
@@ -92,5 +99,4 @@ public class BookService {
     private User validUser(Long userId) {
         return userRepository.findById(userId).orElseThrow(() -> new CustomException(UserErrorCode.NOT_FOUND_USER));
     }
-
 }

--- a/src/main/java/com/book/heejinbook/service/ReviewService.java
+++ b/src/main/java/com/book/heejinbook/service/ReviewService.java
@@ -57,12 +57,7 @@ public class ReviewService {
     public List<ReviewSwiperResponse> getSwiperList(Long bookId, Integer size) {
         Book book = validBook(bookId);
         User user = validUser(AuthHolder.getUserId());
-        Pageable pageable = PageRequest.of(0, size);
-        Page<Review> randomReviews = reviewRepository.findRandomReviews(book, pageable);
-        return randomReviews.getContent().stream().map(review -> {
-            Boolean isLike = likeRepository.existsByUserAndReview(user, review);
-            return ReviewSwiperResponse.from(review, isLike);
-        }).collect(Collectors.toList());
+        return reviewCustomRepository.findBestReviewList(book, user, size);
     }
 
     public PaginationResponse<ReviewListResponse> getList(Long bookId, Pageable pageable, String sort) {


### PR DESCRIPTION
1. 베스트셀러 API 추가 (/api/books/best-books) 평균 별점 상위 3개 조회 (조회 개수 변경은 베스트셀러에 포함 여부 계산을 위해 백단에서 조정해야함 변경 하려면 요청)
2. 책 디테일 조회 시 isBest (현재 베스트셀러인지) 필드 추가
3. 리뷰 스와이퍼 랜덤 값 -> 좋아요 개수 순으로 변경